### PR TITLE
Write tests for password sad paths

### DIFF
--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -33,6 +33,30 @@ RSpec.describe 'new user', type: :feature do
       expect(page).to have_content('Successfully Added New User')
     end
 
+    # Now includes password and password_confirmation SAD PATH 1
+    it 'They fill in form with information, email (unique), submit, MISSING: password, password_confirmation, redirects to user register page, SAD path' do
+      fill_in 'Name', with: "Sammy"
+      fill_in 'Email', with: "sammy@email.com"
+      fill_in 'Password', with: ""
+      fill_in 'Password Confirmation', with: ""
+      click_button 'Create New User'
+
+      expect(current_path).to eq(register_user_path)
+      expect(page).to have_content("Error: Password can't be blank, Password confirmation can't be blank")
+    end
+
+    # Now includes password and password_confirmation SAD PATH 2
+    it 'They fill in form with information, email (unique), submit, Not matching: password, password_confirmation, redirects to user register page, SAD path' do
+      fill_in 'Name', with: "Sammy"
+      fill_in 'Email', with: "sammy@email.com"
+      fill_in 'Password', with: "pw123"
+      fill_in 'Password Confirmation', with: "password123"
+      click_button 'Create New User'
+
+      expect(current_path).to eq(register_user_path)
+      expect(page).to have_content("Error: Password confirmation doesn't match")
+    end
+
     it 'They fill in form with information, email (non-unique), submit, redirects to user show page' do
       fill_in 'Name', with: "Sammy"
       fill_in 'Email', with: "sam_t@email.com"


### PR DESCRIPTION
## Description
Registration (w/ Authentication) Sad Path
```
As a visitor 
When I visit `/register`
and I fail to fill in my name, unique email, OR matching passwords,
I'm taken back to the `/register` page
and a flash message pops up, telling me what went wrong
```

Added testing, functionality was already there

## Type of Change

- [ ] **fix**
- [ ] **feat**
- [x] **test**
- [ ] **refactor**
- [ ] **docs**

## Checklist

- [x] **Code has been self reviewed**
- [x] **Code runs without any errors**
- [ ] **Thorough testing has been implemented if adding feature**
- [x] **All tests pass**
