### PR TITLE
Authen/4 logging in sad

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,11 +22,15 @@ class UsersController < ApplicationController
 
   def login_user
     user = User.find_by(email: params[:email])
+    user[:email] = user[:email].downcase if user
 
-    if user.authenticate(params[:password])
+    if user && user.authenticate(params[:password])
       session[:user_id] = user.id
       flash[:success] = "Welcome, #{user.name}!"
       redirect_to user_discover_index_path(user)
+    else
+      flash[:error] = user ? "Sorry, your password is incorrect." : "Sorry, your email was not found."
+      render :login_form
     end
   end
 

--- a/spec/features/user_can_log_in_spec.rb
+++ b/spec/features/user_can_log_in_spec.rb
@@ -51,4 +51,16 @@ RSpec.describe 'Log in page using credentials: email and password', type: :featu
     expect(current_path).to eq("/login")
     expect(page).to have_content("Sorry, your email was not found.")
   end
+
+  it 'User cannot log in with bad credentials, email does not exist, pw wrong', :vcr do
+    visit '/login'
+    
+    fill_in :email, with: 'sammy@email.com'
+    fill_in :password, with: 'pw123ssss'
+
+    click_on "Log In"
+
+    expect(current_path).to eq("/login")
+    expect(page).to have_content("Sorry, your email was not found.")
+  end
 end

--- a/spec/features/user_can_log_in_spec.rb
+++ b/spec/features/user_can_log_in_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Log in page using credentials: email and password', type: :featu
     expect(page).to have_content("Log Out")
   end
 
-  it 'User cannot log in with bad credentials', :vcr do
+  it 'User cannot log in with bad credentials, wrong password', :vcr do
     visit '/login'
     
     fill_in :email, with: 'sam@email.com'
@@ -37,8 +37,18 @@ RSpec.describe 'Log in page using credentials: email and password', type: :featu
     click_on "Log In"
 
     expect(current_path).to eq("/login")
-    expect(page).to have_content("Sorry, your credentials are bad.")
-    expect(page).to have_content("User Log In")
-    expect(page).to_not have_content("Log Out")
+    expect(page).to have_content("Sorry, your password is incorrect.")
+  end
+
+  it 'User cannot log in with bad credentials, email does not exist', :vcr do
+    visit '/login'
+    
+    fill_in :email, with: 'sammy@email.com'
+    fill_in :password, with: 'pw123'
+
+    click_on "Log In"
+
+    expect(current_path).to eq("/login")
+    expect(page).to have_content("Sorry, your email was not found.")
   end
 end

--- a/spec/features/user_can_log_in_spec.rb
+++ b/spec/features/user_can_log_in_spec.rb
@@ -20,11 +20,25 @@ RSpec.describe 'Log in page using credentials: email and password', type: :featu
     fill_in :password, with: 'pw123'
 
     click_on "Log In"
-save_and_open_page
+
     expect(current_path).to eq("/users/#{@user.id}/discover")
     expect(page).to have_content("Welcome, #{@user.name}!")
 
     expect(page).to_not have_content("User Log In")
     expect(page).to have_content("Log Out")
+  end
+
+  it 'User cannot log in with bad credentials', :vcr do
+    visit '/login'
+    
+    fill_in :email, with: 'sam@email.com'
+    fill_in :password, with: 'badpassword'
+
+    click_on "Log In"
+
+    expect(current_path).to eq("/login")
+    expect(page).to have_content("Sorry, your credentials are bad.")
+    expect(page).to have_content("User Log In")
+    expect(page).to_not have_content("Log Out")
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,5 +25,11 @@ RSpec.describe User, type: :model do
       expect(user).to_not have_attribute(:password)
       expect(user.password_digest).to_not eq('password123')
     end
+
+    it 'does not create user with non-matching password and password confirmation' do
+      user = User.new(name: 'Meg', email: 'meg@test.com', password: 'password123', password_confirmation: 'differentpassword')
+      expect(user.save).to be_falsey
+      expect(user.errors.full_messages).to include("Password confirmation doesn't match Password")
+    end
   end
 end


### PR DESCRIPTION
## Description
Logging In Sad Path
```
As a registered user
When I visit the landing page `/`
And click on the link to go to my dashboard
And fail to fill in my correct credentials 
I'm taken back to the Log In page
And I can see a flash message telling me that I entered incorrect credentials. 
```
Also added SAD path for invalid email.
## Type of Change

- [ ] **fix**
- [x] **feat**
- [x] **test**
- [x] **refactor**
- [ ] **docs**

## Checklist

- [x] **Code has been self reviewed**
- [x] **Code runs without any errors**
- [x] **Thorough testing has been implemented if adding feature**
- [x] **All tests pass**
